### PR TITLE
give aws even more time to set up ec2 instance

### DIFF
--- a/.github/workflows/run_instance.yml
+++ b/.github/workflows/run_instance.yml
@@ -28,6 +28,6 @@ jobs:
     - name: set key permissions
       run: chmod 600 Neurophotonics.pem
     - name: Wait for instance to start # potential spot for improvement
-      run: sleep 10
+      run: sleep 20
     - name: start remote script
       run: ssh -o StrictHostKeyChecking=no -i Neurophotonics.pem ${{ secrets.REMOTE_ADDRESS }} 'screen -d -m sh startup.sh'


### PR DESCRIPTION
This merge will give aws even more time to spin up the ec2 instance. Should fix the issue with the action failing on the second job.
