### PR TITLE
sidestep datajoint python bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Be sure to add an environment file called `docker/dev.env` file with the followi
 DJ_HOST={database host}
 DJ_USER={username} 
 DJ_PASS={password}
+AWS_ACCESS_KEY={access id}
+AWS_ACCESS_SECRET={access password}
+DATABASE_PREFIX={prefix}
 ```
 
-Fill these fields in with the credentials of a user who is added to the neurophotonics database.
+Fill the DJ fields in with the credentials of a user who is added to the neurophotonics database.
+Fill the AWS fields with the AWS worker credentials found in lastpass
+

--- a/scripts/pop_demix.py
+++ b/scripts/pop_demix.py
@@ -1,6 +1,23 @@
 from neurophotonics.demix import *
 
-IlluminationCycle.populate(reserve_jobs=True, processes=1024, display_progress=False)
-Demix.populate('sample<=5', display_progress=False, processes=1024, reserve_jobs=True)
-Cosine.populate(reserve_jobs=True, display_progress=False, processes=1024)
-SpikeSNR.populate(reserve_jobs=True, display_progress=False, processes=1024)
+try:
+    IlluminationCycle.populate(reserve_jobs=True, processes=1024, display_progress=False)
+except ValueError:
+    print("IlluminationCycle already populated")
+
+try:
+    Demix.populate('sample<=5', display_progress=False, processes=1024, reserve_jobs=True)
+except ValueError:
+    print("Demix already populated")
+
+try:
+    Cosine.populate(reserve_jobs=True, display_progress=False, processes=1024)
+except ValueError:
+    print("Cosine already populated")
+
+
+try:
+    SpikeSNR.populate(reserve_jobs=True, display_progress=False, processes=1024)
+except ValueError:
+    print("SpikeSNR already populated")
+

--- a/scripts/pop_fields.py
+++ b/scripts/pop_fields.py
@@ -1,4 +1,11 @@
 from neurophotonics.fields import *
 
-EField.populate(reserve_jobs=True, processes=1024, display_progress=False)
-DField.populate(reserve_jobs=True, processes=1024, display_progress=False)
+try:
+    EField.populate(reserve_jobs=True, processes=1024, display_progress=False)
+except ValueError:
+    print("Efield already populated")
+
+try:
+    DField.populate(reserve_jobs=True, processes=1024, display_progress=False)
+except ValueError:
+    print("Dfield already populated")

--- a/scripts/pop_geo.py
+++ b/scripts/pop_geo.py
@@ -1,2 +1,6 @@
 from neurophotonics.design import Geometry
-Geometry.populate(reserve_jobs=True, display_progress=False, processes=1024)
+
+try:
+    Geometry.populate(reserve_jobs=True, display_progress=False, processes=1024)
+except ValueError:
+    print("Geometry already populated")

--- a/scripts/pop_sim.py
+++ b/scripts/pop_sim.py
@@ -1,4 +1,16 @@
 from neurophotonics.sim import Tissue, Fluorescence, Detection
-Tissue.populate(reserve_jobs=True, display_progress=False, processes=1024)
-Detection.populate(reserve_jobs=True, display_progress=False, processes=1024)
-Fluorescence.populate(reserve_jobs=True, display_progress=False, processes=1024)
+
+try:
+    Tissue.populate(reserve_jobs=True, display_progress=False, processes=1024)
+except ValueError:
+    print("Tissue already populated")
+
+try:
+    Detection.populate(reserve_jobs=True, display_progress=False, processes=1024)
+except ValueError:
+    print("Detection already populated")
+
+try:
+    Fluorescence.populate(reserve_jobs=True, display_progress=False, processes=1024)
+except ValueError:
+    print(" already populated")


### PR DESCRIPTION
This pr should sidestep a [bug](https://github.com/datajoint/datajoint-python/issues/1013) found in datajoint python by surrounding each run in a try except block. This can be undone once the bug is fixed, but shouldn't cause a problem if it reamins after that.

Without it, trying to populate a previously populated table while also specifying multi-processing is to be used raises ValueError("Number of processes must be at least 1") as seen [here](https://github.com/datajoint-company/neurophotonics/blob/logs/log_2022-04-27_13-19-50.txt).