### PR TITLE
add startup script to github

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -7,10 +7,9 @@ git pull origin master
 
 echo "Starting run..."
 start_time=$(date +"%Y-%m-%d_%H:%M:%S")
-WORKER_COUNT=1 HOST_UID=$(id -u) podman-compose -f ./docker/docker-compose-dev.yaml up --build
+WORKER_COUNT=1 HOST_UID=$(id -u) podman-compose -f ./docker/docker-compose-dev.yaml up --build > log_${start_time}.txt 2>&1
 
 echo "Saving logs..."
-echo "$(podman-compose -f ./docker/docker-compose-dev.yaml logs)" > log_${start_time}.txt
 git checkout logs
 git add log_${start_time}.txt
 git commit -m "Add log for run on ${start_time}"

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+echo "Setting up..."
+git checkout master
+docker-compose -f ./docker/docker-compose-dev.yaml down
+git pull origin master
+
+echo "Starting run..."
+start_time=$(date +"%Y-%m-%d_%H:%M:%S")
+WORKER_COUNT=1 HOST_UID=$(id -u) docker-compose -f ./docker/docker-compose-dev.yaml up --build
+
+echo "Saving logs..."
+echo "$(podman-compose -f ./docker/docker-compose-dev.yaml logs)" > log_${start_time}.txt
+git checkout logs
+git add log_${start_time}.txt
+git commit -m "Add log for run on ${start_time}"
+git push origin logs
+
+echo "Ending run..."
+git checkout master
+docker-compose -f ./docker/docker-compose-dev.yaml down
+
+echo "Shutting down..."
+sudo poweroff

--- a/startup.sh
+++ b/startup.sh
@@ -2,12 +2,12 @@
 
 echo "Setting up..."
 git checkout master
-docker-compose -f ./docker/docker-compose-dev.yaml down
+podman-compose -f ./docker/docker-compose-dev.yaml down
 git pull origin master
 
 echo "Starting run..."
 start_time=$(date +"%Y-%m-%d_%H:%M:%S")
-WORKER_COUNT=1 HOST_UID=$(id -u) docker-compose -f ./docker/docker-compose-dev.yaml up --build
+WORKER_COUNT=1 HOST_UID=$(id -u) podman-compose -f ./docker/docker-compose-dev.yaml up --build
 
 echo "Saving logs..."
 echo "$(podman-compose -f ./docker/docker-compose-dev.yaml logs)" > log_${start_time}.txt
@@ -18,7 +18,7 @@ git push origin logs
 
 echo "Ending run..."
 git checkout master
-docker-compose -f ./docker/docker-compose-dev.yaml down
+podman-compose -f ./docker/docker-compose-dev.yaml down
 
 echo "Shutting down..."
 sudo poweroff


### PR DESCRIPTION
In this PR, I moved the repository on the ec2 instance to be in the home directory, so the startup script can now be stored in the repository. This is the script which is run when the ec2 job starts. It will:
- pull from master
- compose up, running whatever is specified in the docker compose file
- save a log to the logs branch
- and shut itself down