### PR TITLE
Update docker-compose-notebook.yaml

### DIFF
--- a/docker/docker-compose-notebook.yaml
+++ b/docker/docker-compose-notebook.yaml
@@ -1,6 +1,5 @@
-# WORKER_COUNT=1 HOST_UID=$(id -u) docker-compose -f ./docker/docker-compose-standard_worker.yaml -p neurophotonics_standard up -d
-# WORKER_COUNT=1 HOST_UID=$(id -u) docker-compose -f ./docker/docker-compose-standard_worker.yaml -p neurophotonics_standard up --build -d
-# docker-compose -f ./docker/docker-compose-standard_worker.yaml -p neurophotonics_standard down
+# WORKER_COUNT=1 HOST_UID=$(id -u) docker-compose -f ./docker/docker-compose-notebook.yaml -p neurophotonics_standard up --build -d
+# docker-compose -f ./docker/docker-compose-notebook.yaml -p neurophotonics_standard down
 # Build this image from neurophotonics level on your local machine
 version: '2.4'
 services:


### PR DESCRIPTION
This  PR alters the comments on the notebook compose file to use the notebook file instead of the standard worker