### PR TITLE
Revert datajoint dependency

### DIFF
--- a/check_db.sh
+++ b/check_db.sh
@@ -1,5 +1,5 @@
 keys=0
-podman-compose -f ./docker/docker-compose-dev.yaml logs 2> /dev/null |\
+podman-compose logs neurophotonics_standard_standard_worker_1 2> /dev/null |\
   grep -E '^keys\s+processed:\s*[0-9]+$' |\
   while read line ; 
     do keys=$(( $keys + ${line:16} )) ; 

--- a/docker/docker-compose-standard_worker.yaml
+++ b/docker/docker-compose-standard_worker.yaml
@@ -16,13 +16,6 @@ services:
       - NEW_USER=datajoint
       - NEW_HOME=/home/.anaconda
     user: ${HOST_UID}:anaconda
-    volumes:
-      - ../setup.py:/main/setup.py
-      - ../requirements.txt:/main/requirements.txt
-      - ../README.md:/main/README.md
-      - ../scripts:/main/scripts
-      - ../neurophotonics:/main/neurophotonics
-      - ../workdir:/main/workdir
     scale: ${WORKER_COUNT:-1}
     command:
       - /bin/bash
@@ -30,4 +23,5 @@ services:
       - |
         set -e
         echo "Running standard_worker..."
-        run_workflow standard_worker
+        run_workflow standard_worker || echo "docker-compose-standard_worker workflow failed"
+        echo "Finished standard_worker"

--- a/neurophotonics/populate/worker.py
+++ b/neurophotonics/populate/worker.py
@@ -26,15 +26,25 @@ standard_worker = DataJointWorker('standard_worker',
                                   autoclear_error_patterns=autoclear_error_patterns)
 
 standard_worker(fields.EField, processes=1024)
+print("keys processed:", fields.EField.progress(display=False)[0])
 standard_worker(fields.DField, processes=1024)
+print("keys processed:", fields.DField.progress(display=False)[0])
 
 standard_worker(design.Geometry, processes=1024)
+print("keys processed:", design.Geometry.progress(display=False)[0])
 
 standard_worker(sim.Tissue, processes=1024)
+print("keys processed:", sim.Tissue.progress(display=False)[0])
 standard_worker(sim.Detection, processes=2)
+print("keys processed:", sim.Detection.progress(display=False)[0])
 standard_worker(sim.Fluorescence, processes=2)
+print("keys processed:", sim.Fluorescence.progress(display=False)[0])
 
 standard_worker(demix.IlluminationCycle, processes=2)
+print("keys processed:", demix.IlluminationCycle.progress(display=False)[0])
 standard_worker(demix.Demix, processes=1024)
+print("keys processed:", demix.Demix.progress(display=False)[0])
 standard_worker(demix.Cosine, processes=1)
+print("keys processed:", demix.Cosine.progress(display=False)[0])
 standard_worker(demix.SpikeSNR, processes=1)
+print("keys processed:", demix.SpikeSNR.progress(display=False)[0])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-datajoint @ git+https://github.com/Ernaldis/datajoint-python.git
+datajoint
 numpy
 scipy
 matplotlib

--- a/scripts/helper.py
+++ b/scripts/helper.py
@@ -1,2 +1,0 @@
-def keys_used(populate):
-    return populate[1] - len(populate[0])

--- a/scripts/pop_demix.py
+++ b/scripts/pop_demix.py
@@ -1,20 +1,14 @@
 from neurophotonics.demix import *
-from scripts.helper import keys_used
+
+IlluminationCycle.populate(reserve_jobs=True, processes=2, display_progress=False)
+Demix.populate(display_progress=False, processes=1024, reserve_jobs=True)
+Cosine.populate(reserve_jobs=True, display_progress=False, processes=1)
+SpikeSNR.populate(reserve_jobs=True, display_progress=False, processes=1)
 
 print(
     "keys processed:",
-    keys_used(
-        IlluminationCycle.populate(
-            reserve_jobs=True, processes=2, display_progress=False
-        )
-    )
-    + keys_used(
-        Demix.populate(display_progress=False, processes=1024, reserve_jobs=True)
-    )
-    + keys_used(
-        Cosine.populate(reserve_jobs=True, display_progress=False, processes=1)
-    )
-    + keys_used(
-        SpikeSNR.populate(reserve_jobs=True, display_progress=False, processes=1)
-    ),
+    IlluminationCycle.progress(display=False)[0]
+    + Demix.progress(display=False)[0]
+    + Cosine.progress(display=False)[0]
+    + SpikeSNR.progress(display=False)[0],
 )

--- a/scripts/pop_fields.py
+++ b/scripts/pop_fields.py
@@ -1,12 +1,9 @@
 from neurophotonics.fields import *
-from scripts.helper import keys_used
+
+EField.populate(reserve_jobs=True, processes=1024, display_progress=False)
+DField.populate(reserve_jobs=True, processes=1024, display_progress=False)
 
 print(
     "keys processed:",
-    keys_used(
-        EField.populate(reserve_jobs=True, processes=1024, display_progress=False)
-    )
-    + keys_used(
-        DField.populate(reserve_jobs=True, processes=1024, display_progress=False)
-    ),
+    EField.progress(display=False)[0] + DField.progress(display=False)[0],
 )

--- a/scripts/pop_geo.py
+++ b/scripts/pop_geo.py
@@ -1,9 +1,9 @@
 from neurophotonics.design import Geometry
-from scripts.helper import keys_used
+
+Geometry.populate(reserve_jobs=True, display_progress=False, processes=1024)
+
 
 print(
     "keys processed:",
-    keys_used(
-        Geometry.populate(reserve_jobs=True, display_progress=False, processes=1024)
-    ),
+    Geometry.progress(display=False)[0],
 )

--- a/scripts/pop_sim.py
+++ b/scripts/pop_sim.py
@@ -1,15 +1,12 @@
 from neurophotonics.pipeline.sim import Tissue, Fluorescence, Detection
-from scripts.helper import keys_used
+
+Tissue.populate(reserve_jobs=True, display_progress=False, processes=1024)
+Detection.populate(reserve_jobs=True, display_progress=False, processes=2)
+Fluorescence.populate(reserve_jobs=True, display_progress=False, processes=2)
 
 print(
     "keys processed:",
-    keys_used(
-        Tissue.populate(reserve_jobs=True, display_progress=False, processes=1024)
-    )
-    + keys_used(
-        Detection.populate(reserve_jobs=True, display_progress=False, processes=2)
-    )
-    + keys_used(
-        Fluorescence.populate(reserve_jobs=True, display_progress=False, processes=2)
-    ),
+    Tissue.progress(display=False)[0]
+    + Detection.progress(display=False)[0]
+    + Fluorescence.progress(display=False)[0],
 )


### PR DESCRIPTION
This PR reverts the datajoint dependency from pointing to my fork back to the company's central repository. It also alters the way that the number of keys processed is checked.
Both the standard worker and the key checking script have successfully ran locally.